### PR TITLE
Improve ability to determine if GPS is fixed and valid

### DIFF
--- a/firmware/TinyGPS++.cpp
+++ b/firmware/TinyGPS++.cpp
@@ -355,6 +355,7 @@ void TinyGPSLocation::commit()
     rawLngData = rawNewLngData;
     lastCommitTime = millis();
     valid = updated = true;
+    if (rawLngData.deg == 0.0 || rawLatData.deg == 0.0) { valid = false; }
 }
 
 void TinyGPSLocation::setLatitude(const char *term)
@@ -386,6 +387,7 @@ void TinyGPSDate::commit()
     date = newDate;
     lastCommitTime = millis();
     valid = updated = true;
+    if (date == 0) { valid = false; }
 }
 
 void TinyGPSTime::commit()
@@ -393,6 +395,7 @@ void TinyGPSTime::commit()
     time = newTime;
     lastCommitTime = millis();
     valid = updated = true;
+    if (time == 0) { valid = false; }
 }
 
 void TinyGPSTime::setTime(const char *term) { newTime = (uint32_t)TinyGPSPlus::parseDecimal(term); }

--- a/firmware/TinyGPS++.cpp
+++ b/firmware/TinyGPS++.cpp
@@ -175,6 +175,7 @@ bool TinyGPSPlus::endOfTermHandler()
             case GPS_SENTENCE_GPRMC:
                 date.commit();
                 time.commit();
+                fix = sentenceHasFix;
                 if(sentenceHasFix)
                 {
                     location.commit();
@@ -184,6 +185,7 @@ bool TinyGPSPlus::endOfTermHandler()
                 break;
             case GPS_SENTENCE_GPGGA:
                 time.commit();
+                fix = sentenceHasFix;
                 if(sentenceHasFix)
                 {
                     location.commit();

--- a/firmware/TinyGPS++.h
+++ b/firmware/TinyGPS++.h
@@ -269,6 +269,7 @@ public:
     uint32_t sentencesWithFix() const { return sentencesWithFixCount; }
     uint32_t failedChecksum() const { return failedChecksumCount; }
     uint32_t passedChecksum() const { return passedChecksumCount; }
+    bool isFixed() const { return fix; }
 
 private:
     enum
@@ -286,6 +287,7 @@ private:
     uint8_t curTermNumber;
     uint8_t curTermOffset;
     bool sentenceHasFix;
+    bool fix; // fix state of last NMEA message containing fix
 
     // custom element support
     friend class TinyGPSCustom;


### PR DESCRIPTION
The `TinyGPS++` library currently does not expose any way for the user-programmer to determine if the GPS module has a fix. In addition, the `isValid` method on `TinyGPSLocation`, `TinyGPSDate` and `TinyGPSTime` was returning true when the data was not yet populated.

This PR introduces a new `isFixed()` method to the `TinyGPSPlus` class. It returns the fix state of the last NMEA sentence that contains a fix flag.

In addition, the `isValid` methods, mentioned above, now return `false` if the underlying data has not yet been populated.